### PR TITLE
Add a converter for latitude/longitude pairs

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -10,7 +10,7 @@
 #downloadMap {
   visibility: hidden;
 }
-.coords {
+.coords,.pairs {
   margin: 4px;
   padding: 10px;
   background-color: #add8e6;

--- a/index.html
+++ b/index.html
@@ -35,11 +35,17 @@
         <span class="lat">Latitude: <input type="text" name="lat_0" value="36°57'9&#034; N"></span><br>
         <span class="lon">Longitude: <input type="text" name="lon_0" value="110°4'21&#034; W"></span><br>
       </div>
+      <div class="pairs">
+        <p>Latitude and longitude pairs. Each will be paired up into a polygon. Delineate pairs by comma (,).</p>
+        <span class="lat">Latitudes: <input type="text" name="lats" value="36°57'9&#034; N, 37°57'9&#034; N"></span><br>
+        <span class="lon">Longitudes: <input type="text" name="lons" value="110°4'21&#034; W, 111°4'21&#034; W"></span><br>
+      </div>
     </div>
     <br>
     <div id="buttons">
         <button id="addpoint" onclick="addPoint()">Add Point</button>
         <button id="convertpoints" class="submit" onclick="convertPoints()">Convert Points Input</button>
+        <button id="convertpairs" class="submit" onclick="convertPairs()">Convert Pairs Input</button>
         <div id="togglecontainer">
           <div id="systemtoggle">
             <div id="epsg3857label">EPSG:3857</div>


### PR DESCRIPTION
This addition is to support cases where people send a request to map a region as a pair of latitudes and longitudes like this:

> AOI coordinate: LAT between -9.646536 and 6.998524, LON between 94.51485 and 140.9909

If they then put those in the `Latitudes` and `Longitudes` boxes separated by `,` it'll be converted to coordinates and mapped.

Example:
<img width="1062" src="https://user-images.githubusercontent.com/18167/81386593-d3c79780-9147-11ea-9f58-36c856130887.png">


![2020-05-08 16 15 39](https://user-images.githubusercontent.com/18167/81386207-34a2a000-9147-11ea-9663-138446c5709c.jpg)
(the convention in my team at work is to also give a cute animal with each PR, and I see no reason to not do that :p)